### PR TITLE
Enable pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,14 @@
 from setuptools import setup
 
-setup(name="octo", packages=["octo"])
+setup(
+    name="octo",
+    version="0.0.1",
+    packages=find_packages(),
+    python_requires=">=3.8",
+    install_requires=[
+      "jax>=0.4.20",
+      "jaxlib>=0.4.20",
+      "dlimp @ git+https://github.com/kvablack/dlimp@d08da3852c149548aaa8551186d619d87375df08",
+      "tensorflow_datasets <= 4.9.3",  # Required for gsutil to work as intended. See https://github.com/tensorflow/datasets/issues/5203.
+    ],
+)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import find_packages, setup
 
 setup(
     name="octo",


### PR DESCRIPTION
This allows for dependencies like `python -m pip install git+https://github.com/octo-models/octo`.

See https://colab.research.google.com/drive/1Arhc2gvfMmWUEDCYqeopSKr0zzzfx8Q-#scrollTo=2ZDF2sSQ8hmB.

Fixes #45