### PR TITLE
Add Robomimic Policy Training Support

### DIFF
--- a/octo/data/dataset.py
+++ b/octo/data/dataset.py
@@ -450,6 +450,51 @@ def make_single_dataset(
     dataset.dataset_statistics = dataset_statistics
     return dataset
 
+def get_combined_dataset_statistics(
+    all_dataset_statistics: Sequence[dict],
+) -> dict:
+    all_traj_keys = ['action', 'proprio']
+    # Get combined dataset_statistics
+    combined_dataset_statistics = copy.deepcopy(all_dataset_statistics[0])
+    for i, stat_dict in enumerate(all_dataset_statistics):
+        for traj_key in all_traj_keys:
+            combined_dataset_statistics[traj_key]['min'] = np.array(combined_dataset_statistics[traj_key]['min'])
+            combined_dataset_statistics[traj_key]['max'] = np.array(combined_dataset_statistics[traj_key]['max'])
+            combined_dataset_statistics[traj_key]['mean'] = np.zeros(len(combined_dataset_statistics[traj_key]['mean']))
+            combined_dataset_statistics[traj_key]['std'] = np.zeros(len(combined_dataset_statistics[traj_key]['std']))
+
+            all_dataset_statistics[i][traj_key]['min'] = np.array(stat_dict[traj_key]['min'])
+            all_dataset_statistics[i][traj_key]['max'] = np.array(stat_dict[traj_key]['max'])
+            all_dataset_statistics[i][traj_key]['mean'] = np.array(stat_dict[traj_key]['mean'])
+            all_dataset_statistics[i][traj_key]['std'] = np.array(stat_dict[traj_key]['std'])
+
+    total_transitions = 0
+    total_trajectories = 0
+    for stat_dict in all_dataset_statistics:
+        for traj_key in all_traj_keys:
+            combined_dataset_statistics[traj_key]['min'] = np.minimum(combined_dataset_statistics[traj_key]['min'],
+                                                                stat_dict[traj_key]['min'])
+            combined_dataset_statistics[traj_key]['max'] = np.maximum(combined_dataset_statistics[traj_key]['max'],
+                                                                stat_dict[traj_key]['max'])
+            combined_dataset_statistics[traj_key]['mean'] += stat_dict['num_transitions'] * stat_dict[traj_key]['mean']
+            total_transitions += stat_dict['num_transitions']
+            total_trajectories += stat_dict['num_trajectories']
+
+    combined_dataset_statistics['num_transitions'] = total_transitions
+    combined_dataset_statistics['num_trajectories'] = total_trajectories
+
+    for traj_key in all_traj_keys:
+        combined_dataset_statistics[traj_key]['mean'] /= total_transitions
+
+    for stat_dict in all_dataset_statistics:
+        for traj_key in all_traj_keys:
+            combined_dataset_statistics[traj_key]['std'] += ((stat_dict['num_transitions'] - 1) * stat_dict[traj_key]['std']**2)
+            combined_dataset_statistics[traj_key]['std'] += (stat_dict['num_transitions'] *  (stat_dict[traj_key]['mean'] - combined_dataset_statistics[traj_key]['mean'])**2)
+
+    for traj_key in all_traj_keys:
+        combined_dataset_statistics[traj_key]['std'] /= (total_transitions - 1)
+
+    return combined_dataset_statistics
 
 def make_interleaved_dataset(
     dataset_kwargs_list: Sequence[dict],
@@ -461,6 +506,7 @@ def make_interleaved_dataset(
     frame_transform_kwargs: dict = {},
     batch_size: Optional[int] = None,
     balance_weights: bool = False,
+    do_combined_normalization: bool = False,
     traj_transform_threads: Optional[int] = None,
     traj_read_threads: Optional[int] = None,
 ) -> dl.DLataset:
@@ -502,47 +548,8 @@ def make_interleaved_dataset(
         dataset_sizes.append(dataset_statistics["num_transitions"])
         all_dataset_statistics.append(dataset_statistics)
 
-    # Get combined dataset_statistics
-    traj_keys = ['action', 'proprio'] # TODO(don't hardocde)
-    combined_dataset_statistics = copy.deepcopy(all_dataset_statistics[0])
-    for i, stat_dict in enumerate(all_dataset_statistics):
-        for traj_key in traj_keys:
-            combined_dataset_statistics[traj_key]['min'] = np.array(combined_dataset_statistics[traj_key]['min'])
-            combined_dataset_statistics[traj_key]['max'] = np.array(combined_dataset_statistics[traj_key]['max'])
-            combined_dataset_statistics[traj_key]['mean'] = np.zeros(len(combined_dataset_statistics[traj_key]['mean']))
-            combined_dataset_statistics[traj_key]['std'] = np.zeros(len(combined_dataset_statistics[traj_key]['std']))
-
-            all_dataset_statistics[i][traj_key]['min'] = np.array(stat_dict[traj_key]['min'])
-            all_dataset_statistics[i][traj_key]['max'] = np.array(stat_dict[traj_key]['max'])
-            all_dataset_statistics[i][traj_key]['mean'] = np.array(stat_dict[traj_key]['mean'])
-            all_dataset_statistics[i][traj_key]['std'] = np.array(stat_dict[traj_key]['std'])
-
-    total_transitions = 0
-    total_trajectories = 0
-    for stat_dict in all_dataset_statistics:
-        for traj_key in traj_keys:
-            combined_dataset_statistics[traj_key]['min'] = np.minimum(combined_dataset_statistics[traj_key]['min'],
-                                                                stat_dict[traj_key]['min'])
-            combined_dataset_statistics[traj_key]['max'] = np.maximum(combined_dataset_statistics[traj_key]['max'],
-                                                                stat_dict[traj_key]['max'])
-            combined_dataset_statistics[traj_key]['mean'] += stat_dict['num_transitions'] * stat_dict[traj_key]['mean']
-            total_transitions += stat_dict['num_transitions']
-            total_trajectories += stat_dict['num_trajectories']
-
-    combined_dataset_statistics['num_transitions'] = total_transitions
-    combined_dataset_statistics['num_trajectories'] = total_trajectories
-
-    for traj_key in traj_keys:
-        combined_dataset_statistics[traj_key]['mean'] /= total_transitions
-
-    for stat_dict in all_dataset_statistics:
-        for traj_key in traj_keys:
-            combined_dataset_statistics[traj_key]['std'] += ((stat_dict['num_transitions'] - 1) * stat_dict[traj_key]['std']**2)
-            combined_dataset_statistics[traj_key]['std'] += (stat_dict['num_transitions'] *  (stat_dict[traj_key]['mean'] - combined_dataset_statistics[traj_key]['mean'])**2)
-
-    for traj_key in traj_keys:
-        combined_dataset_statistics[traj_key]['std'] /= (total_transitions - 1)
-
+    combined_dataset_statistics = get_combined_dataset_statistics(
+        all_dataset_statistics)
 
     # balance and normalize weights
     if balance_weights:
@@ -559,8 +566,9 @@ def make_interleaved_dataset(
 
     # construct datasets
     datasets = []
-    for dataset_kwargs, threads, reads in zip(
+    for dataset_kwargs, dataset_statistics, threads, reads in zip(
         dataset_kwargs_list,
+        all_dataset_statistics,
         threads_per_dataset,
         reads_per_dataset,
     ):
@@ -569,7 +577,7 @@ def make_interleaved_dataset(
             train=train,
             num_parallel_calls=threads,
             num_parallel_reads=reads,
-            dataset_statistics=combined_dataset_statistics,
+            dataset_statistics=combined_dataset_statistics if do_combined_normalization else dataset_statistics,
         )
         dataset = apply_trajectory_transforms(
             dataset.repeat(),
@@ -595,6 +603,6 @@ def make_interleaved_dataset(
     dataset = dataset.with_ram_budget(1)
 
     # save for later
-    dataset.dataset_statistics = combined_dataset_statistics
+    dataset.dataset_statistics = combined_dataset_statistics if do_combined_normalization else all_dataset_statistics
     dataset.sample_weights = sample_weights
     return dataset

--- a/octo/data/dataset.py
+++ b/octo/data/dataset.py
@@ -15,7 +15,7 @@ from octo.data.utils.data_utils import (
     allocate_threads,
     get_dataset_statistics,
     NormalizationType,
-    normalize_action_and_proprio,
+    normalize_traj_keys,
     pprint_data_mixture,
     tree_map,
 )
@@ -209,6 +209,7 @@ def make_dataset_from_rlds(
     state_obs_keys: Sequence[Optional[str]] = (),
     language_key: Optional[str] = None,
     action_proprio_normalization_type: NormalizationType = NormalizationType.NORMAL,
+    keys_to_normalize: Optional[dict] = None,
     dataset_statistics: Optional[Union[dict, str]] = None,
     absolute_action_mask: Optional[Sequence[bool]] = None,
     action_normalization_mask: Optional[Sequence[bool]] = None,
@@ -408,9 +409,10 @@ def make_dataset_from_rlds(
     dataset = dataset.traj_map(restructure, num_parallel_calls)
     dataset = dataset.traj_map(
         partial(
-            normalize_action_and_proprio,
+            normalize_traj_keys,
             metadata=dataset_statistics,
             normalization_type=action_proprio_normalization_type,
+            keys_to_normalize=keys_to_normalize,
         ),
         num_parallel_calls,
     )

--- a/octo/data/utils/data_utils.py
+++ b/octo/data/utils/data_utils.py
@@ -181,15 +181,16 @@ def get_dataset_statistics(
     return metadata
 
 
-def normalize_action_and_proprio(
-    traj: dict, metadata: dict, normalization_type: NormalizationType
+def normalize_traj_keys(
+    traj: dict, metadata: dict, normalization_type: NormalizationType, keys_to_normalize=None
 ):
-    """Normalizes the action and proprio fields of a trajectory using the given metadata."""
+    """Normalizes the specified fields of a trajectory using the given metadata."""
     # maps keys of `metadata` to corresponding keys in `traj`
-    keys_to_normalize = {
-        "action": "action",
-        "proprio": "observation/proprio",
-    }
+    if keys_to_normalize is None:
+        keys_to_normalize = {
+            "action": "action",
+            "proprio": "observation/proprio",
+        }
     if normalization_type == NormalizationType.NORMAL:
         # normalize to mean 0, std 1
         for key, traj_key in keys_to_normalize.items():


### PR DESCRIPTION
There are two main changes here:

1) Support to specify what trajectory keys to normalize, defaults to the original action and proprio keys.
2) When creating an interleaved dataset which mixes together multiple individual datasets, dataset statistics used for normalization are combined across all datasets.