### PR TITLE
Fixed int * float multiplication error

### DIFF
--- a/examples/06_pytorch_oxe_dataloader.py
+++ b/examples/06_pytorch_oxe_dataloader.py
@@ -39,7 +39,7 @@ class TorchRLDSDataset(torch.utils.data.IterableDataset):
             ]
         )
         if hasattr(self._rlds_dataset, "sample_weights"):
-            lengths *= np.array(self._rlds_dataset.sample_weights)
+            lengths = np.array(self._rlds_dataset.sample_weights) * lengths
         total_len = lengths.sum()
         if self._is_train:
             return int(0.95 * total_len)


### PR DESCRIPTION
Fixed len call throwing error when attribute "sample_weights" is provided. Since "num_transitions" is an int value, multiplying it with a float threw an error. I simply switched it around, since "sample_weights" is either int / float and "num_transitions" is always int.