### PR TITLE
Add option to provide stats to make_interleaved_dataset and skip keys during norm

### DIFF
--- a/examples/06_pytorch_oxe_dataloader.py
+++ b/examples/06_pytorch_oxe_dataloader.py
@@ -4,12 +4,13 @@ dataloader. The config below also happens to be our exact pretraining config (ex
 shuffle buffer size, which are reduced for demonstration purposes).
 """
 import numpy as np
-from octo.data.dataset import make_interleaved_dataset
-from octo.data.oxe import make_oxe_dataset_kwargs_and_weights
 import tensorflow as tf
 import torch
 from torch.utils.data import DataLoader
 import tqdm
+
+from octo.data.dataset import make_interleaved_dataset
+from octo.data.oxe import make_oxe_dataset_kwargs_and_weights
 
 DATA_PATH = "gs://rail-orca-central2/resize_256_256"
 

--- a/octo/data/dataset.py
+++ b/octo/data/dataset.py
@@ -511,9 +511,9 @@ def make_interleaved_dataset(
     dataset_sizes = []
     all_dataset_statistics = []
     for dataset_kwargs in dataset_kwargs_list:
-        _, data_stats = make_dataset_from_rlds(**dataset_kwargs, train=train)
-        dataset_sizes.append(data_stats["num_transitions"])
-        all_dataset_statistics.append(data_stats)
+        _, per_dataset_stats = make_dataset_from_rlds(**dataset_kwargs, train=train)
+        dataset_sizes.append(per_dataset_stats["num_transitions"])
+        all_dataset_statistics.append(per_dataset_stats)
 
     # balance and normalize weights
     if balance_weights:
@@ -530,7 +530,7 @@ def make_interleaved_dataset(
 
     # construct datasets
     datasets = []
-    for dataset_kwargs, data_stats, threads, reads in zip(
+    for dataset_kwargs, per_dataset_stats, threads, reads in zip(
         dataset_kwargs_list,
         all_dataset_statistics,
         threads_per_dataset,
@@ -543,7 +543,7 @@ def make_interleaved_dataset(
             num_parallel_reads=reads,
             dataset_statistics=dataset_statistics
             if dataset_statistics is not None
-            else data_stats,
+            else per_dataset_stats,
         )
         dataset = apply_trajectory_transforms(
             dataset.repeat(),

--- a/octo/data/dataset.py
+++ b/octo/data/dataset.py
@@ -19,6 +19,7 @@ from octo.data.utils.data_utils import (
     pprint_data_mixture,
     tree_map,
 )
+from octo.utils.spec import ModuleSpec
 
 
 def apply_trajectory_transforms(
@@ -213,6 +214,7 @@ def make_dataset_from_rlds(
     absolute_action_mask: Optional[Sequence[bool]] = None,
     action_normalization_mask: Optional[Sequence[bool]] = None,
     norm_skip_keys: Optional[Sequence[str]] = None,
+    filter_functions: Sequence[ModuleSpec] = (),
     num_parallel_reads: int = tf.data.AUTOTUNE,
     num_parallel_calls: int = tf.data.AUTOTUNE,
 ) -> Tuple[dl.DLataset, dict]:
@@ -274,6 +276,8 @@ def make_dataset_from_rlds(
             should be normalized. For example, you might not want to normalize the gripper action dimension if
             it's always exactly 0 or 1. By default, all action dimensions are normalized.
         norm_skip_keys (Sequence[str], optional): Provided keys will be skipped during normalization.
+        filter_functions (Sequence[ModuleSpec]): ModuleSpecs for filtering functions applied to the
+            raw dataset.
         num_parallel_reads (int): number of parallel read workers. Default to AUTOTUNE.
         num_parallel_calls (int): number of parallel calls for traj_map operations. Default to AUTOTUNE.
     Returns:
@@ -372,7 +376,10 @@ def make_dataset_from_rlds(
     elif dataset_statistics is None:
         full_dataset = dl.DLataset.from_rlds(
             builder, split="all", shuffle=False, num_parallel_reads=num_parallel_reads
-        ).traj_map(restructure, num_parallel_calls)
+        )
+        for filter_fcn_spec in filter_functions:
+            full_dataset = full_dataset.filter(ModuleSpec.instantiate(filter_fcn_spec))
+        full_dataset = full_dataset.traj_map(restructure, num_parallel_calls)
         # tries to load from cache, otherwise computes on the fly
         dataset_statistics = get_dataset_statistics(
             full_dataset,
@@ -380,6 +387,7 @@ def make_dataset_from_rlds(
                 str(builder.info),
                 str(state_obs_keys),
                 inspect.getsource(standardize_fn) if standardize_fn is not None else "",
+                *map(ModuleSpec.to_string, filter_functions),
             ),
             save_dir=builder.data_dir,
         )
@@ -406,7 +414,8 @@ def make_dataset_from_rlds(
     dataset = dl.DLataset.from_rlds(
         builder, split=split, shuffle=shuffle, num_parallel_reads=num_parallel_reads
     )
-
+    for filter_fcn_spec in filter_functions:
+        dataset = dataset.filter(ModuleSpec.instantiate(filter_fcn_spec))
     dataset = dataset.traj_map(restructure, num_parallel_calls)
     dataset = dataset.traj_map(
         partial(

--- a/octo/data/dataset.py
+++ b/octo/data/dataset.py
@@ -532,7 +532,9 @@ def make_interleaved_dataset(
             train=train,
             num_parallel_calls=threads,
             num_parallel_reads=reads,
-            dataset_statistics=dataset_statistics if dataset_statistics is not None else data_stats,
+            dataset_statistics=dataset_statistics
+            if dataset_statistics is not None
+            else data_stats,
         )
         dataset = apply_trajectory_transforms(
             dataset.repeat(),
@@ -559,6 +561,7 @@ def make_interleaved_dataset(
 
     # save for later
     dataset.dataset_statistics = (
-        dataset_statistics if dataset_statistics is not None else all_dataset_statistics)
+        dataset_statistics if dataset_statistics is not None else all_dataset_statistics
+    )
     dataset.sample_weights = sample_weights
     return dataset

--- a/octo/data/utils/data_utils.py
+++ b/octo/data/utils/data_utils.py
@@ -203,25 +203,25 @@ def combine_dataset_statistics(
         ).sum(0)
         # compute combined_std for denominator `n` instead of `n-1` since numpy uses that by default for std
         # https://stats.stackexchange.com/questions/55999/is-it-possible-to-find-the-combined-standard-deviation
-        combined_std = (
+        combined_std = np.sqrt(
             np.array(
                 [
                     n * np.array(stat[key]["std"]) ** 2
                     + n * (np.array(stat[key]["mean"]) - combined_mean) ** 2
-                    for stat, n in zip(combined_dataset_statistics, num_transitions)
+                    for stat, n in zip(all_dataset_statistics, num_transitions)
                 ]
             ).sum(0)
             / sum(num_transitions)
-        ).sqrt()
+        )
         combined_dataset_statistics[key] = {
             "min": np.array([stat[key]["min"] for stat in all_dataset_statistics])
             .min(0)
-            .to_list(),
+            .tolist(),
             "max": np.array([stat[key]["max"] for stat in all_dataset_statistics])
             .max(0)
-            .to_list(),
-            "mean": combined_mean.to_list(),
-            "std": combined_std.to_list(),
+            .tolist(),
+            "mean": combined_mean.tolist(),
+            "std": combined_std.tolist(),
         }
 
     combined_dataset_statistics["num_trajectories"] = num_trajectories

--- a/octo/data/utils/data_utils.py
+++ b/octo/data/utils/data_utils.py
@@ -181,8 +181,45 @@ def get_dataset_statistics(
     return metadata
 
 
+def combine_dataset_statistics(
+    all_dataset_statistics: Sequence[dict],
+) -> dict:
+    """Merges dataset statistics from multiple datasets."""
+    merge_stat_keys = ["action", "proprio"]
+
+    num_trajectories = [stat["num_trajectories"] for stat in all_dataset_statistics]
+    num_transitions = [stat["num_transitions"] for stat in all_dataset_statistics]
+    stat_weights = [transitions / sum(num_transitions) for transitions in num_transitions]
+
+    combined_dataset_statistics = {}
+    for key in merge_stat_keys:
+        combined_mean = np.array(
+            [stat[key]["mean"] * w for stat, w in zip(all_dataset_statistics, stat_weights)]
+        ).sum(0)
+        # compute combined_std for denominator `n` instead of `n-1` since numpy uses that by default for std
+        # https://stats.stackexchange.com/questions/55999/is-it-possible-to-find-the-combined-standard-deviation
+        combined_std = (
+            np.array(
+                [
+                    n * np.array(stat[key]["std"])**2 + n * (np.array(stat[key]["mean"]) - combined_mean)**2
+                    for stat, n in zip(combined_dataset_statistics, num_transitions)
+                ]
+            ).sum(0) / sum(num_transitions)
+        ).sqrt()
+        combined_dataset_statistics[key] = {
+            "min": np.array([stat[key]["min"] for stat in all_dataset_statistics]).min(0).to_list(),
+            "max": np.array([stat[key]["max"] for stat in all_dataset_statistics]).max(0).to_list(),
+            "mean": combined_mean.to_list(),
+            "std": combined_std.to_list(),
+        }
+
+    combined_dataset_statistics["num_trajectories"] = num_trajectories
+    combined_dataset_statistics["num_transitions"] = num_transitions
+    return combined_dataset_statistics
+
+
 def normalize_action_and_proprio(
-    traj: dict, metadata: dict, normalization_type: NormalizationType
+    traj: dict, metadata: dict, normalization_type: NormalizationType, skip_keys=None
 ):
     """Normalizes the action and proprio fields of a trajectory using the given metadata."""
     # maps keys of `metadata` to corresponding keys in `traj`
@@ -190,6 +227,13 @@ def normalize_action_and_proprio(
         "action": "action",
         "proprio": "observation/proprio",
     }
+    if skip_keys is not None:
+        for skip_key in skip_keys:
+            if skip_key not in keys_to_normalize:
+                raise ValueError(f"{skip_key} cannot be skipped during normalization since it's not a valid key, "
+                                 f"choose from {keys_to_normalize.keys()}")
+            keys_to_normalize.pop(skip_key)
+
     if normalization_type == NormalizationType.NORMAL:
         # normalize to mean 0, std 1
         for key, traj_key in keys_to_normalize.items():

--- a/octo/utils/spec.py
+++ b/octo/utils/spec.py
@@ -66,6 +66,15 @@ class ModuleSpec(TypedDict):
         cls = _import_from_string(spec["module"], spec["name"])
         return partial(cls, *spec["args"], **spec["kwargs"])
 
+    @staticmethod
+    def to_string(spec: "ModuleSpec"):  # type: ignore
+        return (
+            f"{spec['module']}:{spec['name']}"
+            f"({', '.join(spec['args'])}"
+            f"{', ' if spec['args'] and spec['kwargs'] else ''}"
+            f"{', '.join(f'{k}={v}' for k, v in spec['kwargs'].items())})"
+        )
+
 
 def _infer_full_name(o: object):
     if hasattr(o, "__module__") and hasattr(o, "__name__"):


### PR DESCRIPTION
Small data loader changes we found helpful during DROID training:
- add optional argument to pass dataset_statistics to `make_interleaved_dataset` that are used for normalization (we still compute individual stats for weight & thread balancing) -- useful if you eg want to do co-training and normalize all datasets with the same stats
- add argument to `make_dataset_from_rlds` that allows to skip keys during normalization (eg in DROID we don't normalize proprio)
- adds utility to compute aggregate dataset stats across a list of stats (eg for co-training setting)

@kvablack would be great to merge this ASAP if you have time to take a look!