### PR TITLE
Fix pad_mask bug: min instead of max for pad_length

### DIFF
--- a/octo/utils/gym_wrappers.py
+++ b/octo/utils/gym_wrappers.py
@@ -17,7 +17,7 @@ def stack_and_pad(history: list, num_obs: int):
     """
     horizon = len(history)
     full_obs = {k: np.stack([dic[k] for dic in history]) for k in history[0]}
-    pad_length = horizon - max(num_obs, horizon)
+    pad_length = horizon - min(num_obs, horizon)
     pad_mask = np.ones(horizon)
     pad_mask[:pad_length] = 0
     full_obs["pad_mask"] = pad_mask


### PR DESCRIPTION
Before this change, the `pad_mask` in observations with history is always all `True`s. However, we would want part of the `pad_mask` to be `False` during the first few timesteps when the number of past observations is shorter than the horizon length.