### PR TITLE
Save the original model config in train script

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -139,6 +139,9 @@ def main(_):
         del batch["dataset_name"]
         return batch
 
+    # copy the original config before we modify it
+    model_config = FLAGS.config.to_dict()
+
     # load datasets
     if "oxe_kwargs" in FLAGS.config.dataset_kwargs:
         # create dataset_kwargs_list from oxe_kwargs
@@ -180,7 +183,7 @@ def main(_):
     rng = jax.random.PRNGKey(FLAGS.config.seed)
     rng, init_rng = jax.random.split(rng)
     model = OctoModel.from_config(
-        FLAGS.config.to_dict(),
+        model_config,
         example_batch,
         text_processor,
         verbose=True,


### PR DESCRIPTION
The train script removes the "oxe_kwargs" key in the config, and add "dataset_kwargs_list" & "sample_weights" to the config. Such behavior causes a `TypeError: Object of type function is not JSON serializable(base)` error when saving model checkpoint, because the `standardize_fn` we put into the model config is not serializable. This commit fixes the issue by preserving the unmodified config.