### PR TITLE
Lang-visual cross attention

### DIFF
--- a/scripts/configs/octo_pretrain_config.py
+++ b/scripts/configs/octo_pretrain_config.py
@@ -49,6 +49,7 @@ def get_config(config_string=None):
             finetune_encoder=False,
         ),
     }
+    config["model"]["repeat_task_tokens"] = True
     config["model"]["readouts"] = {"action": 1}
     config["model"]["heads"]["action"] = ModuleSpec.create(
         DiffusionActionHead,


### PR DESCRIPTION
Adds language visual cross attention by adding tokenized language into an observation (time step) tokenizer. This allows the language to attend back and forth with the visual tokens at the same or prior time steps.